### PR TITLE
Adding webdriver-manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ FROM tiangolo/uwsgi-nginx-flask:python3.9-2021-10-26
 RUN apt-get update
 RUN apt-get install -y firefox-esr
 
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz
-RUN tar -xvzf geckodriver*
-RUN chmod +x geckodriver
-RUN cp geckodriver /usr/bin/geckodriver
-
 COPY requirements.txt /app/requirements.txt
 # Do not use pip-sync here as it removes uwsgi
 RUN pip install --no-cache-dir --disable-pip-version-check -r /app/requirements.txt

--- a/app.py
+++ b/app.py
@@ -12,6 +12,10 @@ from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from selenium.webdriver.chrome.service import Service as ChromeService
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.firefox.service import Service as FirefoxService
+from webdriver_manager.firefox import GeckoDriverManager
 import undetected_chromedriver as uc
 
 app = Flask(__name__)
@@ -232,7 +236,7 @@ def _create_chrome():
     _set_chrome_options(options)
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
     options.add_experimental_option('useAutomationExtension', False)
-    driver = webdriver.Chrome(options=options)
+    driver = webdriver.Chrome(service=ChromeService(ChromeDriverManager().install()), options=options)
     return driver
 
 
@@ -276,7 +280,8 @@ def _create_firefox():
     cap = DesiredCapabilities.FIREFOX
     cap["marionette"] = False
 
-    driver = webdriver.Firefox(options=options, desired_capabilities=cap)
+    driver = webdriver.Firefox(service=FirefoxService(GeckoDriverManager().install()), options=options,
+                               desired_capabilities=cap)
     return driver
 
 

--- a/app.py
+++ b/app.py
@@ -22,8 +22,8 @@ app = Flask(__name__)
 
 _logger = logging.getLogger(__name__)
 _CAPTURE_SCREENSHOTS = False
-_HEADLESS = True
-_DEFAULT_BROWSER = "firefox"
+_HEADLESS = False
+_DEFAULT_BROWSER = "chrome"
 _DEFAULT_DELAY = "random"
 _DEFAULT_WAIT_FOR_ELEMENT_SEC = 30
 _RANDOM_DELAY_MAX_SEC = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ selenium==4.1.3
 flask==2.1.1
 undetected-chromedriver==3.1.5.post4
 requests==2.27.1
+webdriver-manager==3.8.2


### PR DESCRIPTION
add webdriver-manager to simplify management of binary drivers for different browsers.

change the initiate of the webdriver (chrome and firefox) to use webdriver-manager.

add the webdriver-manager to requirements.txt file.

remove from the docker file the installation of the geckodriver.